### PR TITLE
remove regex_flag in MultiRegexPipe

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,9 @@ def pytest_collection_modifyitems(config, items):
 
 @pytest.fixture(scope="session")
 def mecab_tokenizer():
-    if check_mecab():
-        return Mecab.Defaults.create_tokenizer(dicdir="/usr/local/lib/mecab/dic/ipadic")
+    if not check_mecab():
+        pytest.skip("mecab is required")
+    return Mecab.Defaults.create_tokenizer(dicdir="/usr/local/lib/mecab/dic/ipadic")
 
 
 @pytest.fixture(scope="session", params=[True, False])

--- a/tests/pipelines/test_regex_pipe.py
+++ b/tests/pipelines/test_regex_pipe.py
@@ -1,3 +1,4 @@
+import re
 from itertools import zip_longest
 
 import pytest
@@ -9,11 +10,6 @@ from camphr.pipelines.regex_ruler import MultipleRegexRuler, RegexRuler
 
 from ..utils import check_mecab, check_serialization
 
-pytestmark = pytest.mark.skipif(
-    not check_mecab(), reason="mecab is not always necessary"
-)
-
-
 TESTCASES = [
     (
         "16日はいい天気だった",
@@ -23,8 +19,15 @@ TESTCASES = [
 ]
 
 
+@pytest.fixture(params=[True, False])
+def do_compile(request):
+    return request.param
+
+
 @pytest.mark.parametrize("text,patterns,expected", TESTCASES)
-def test_multiple_regex_ruler(mecab_tokenizer, text, patterns, expected):
+def test_multiple_regex_ruler(mecab_tokenizer, text, patterns, expected, do_compile):
+    if do_compile:
+        patterns = {k: re.compile(v) for k, v in patterns.items()}
     doc: Doc = mecab_tokenizer(text)
     ruler = MultipleRegexRuler(patterns)
     doc = ruler(doc)


### PR DESCRIPTION
Constructor argument `regex_flag` doesn't work.
Maybe I should fix it to work properly, I removed this because of performance reason.
Users is still able to pass compiled regex object to the constructor.