### PR TITLE
tag and bunsetsu can be directly get from token

### DIFF
--- a/camphr/pipelines/knp/__init__.py
+++ b/camphr/pipelines/knp/__init__.py
@@ -179,7 +179,7 @@ def _extract_knp_ent(doc: Doc) -> List[Span]:
     ents: List[Tuple[str, int, int]] = []
     for token in doc:
         ent_match = re.search(
-            r"<NE:(\w+):(.*)?>", token._.get(KNP_USER_KEYS.morph.element).fstring
+            r"<NE:(\w+):(.*?)?>", token._.get(KNP_USER_KEYS.morph.element).fstring
         )
         if ent_match:
             ent, loc = ent_match.groups()

--- a/camphr/pipelines/knp/__init__.py
+++ b/camphr/pipelines/knp/__init__.py
@@ -103,6 +103,16 @@ class KNP:
 
 
 @curry
+def token_to_knp_span(type_: str, token: Token) -> Span:
+    """Returns the knp span containing the token."""
+    assert type_ != MORPH
+    for tag_or_bunsetsu in token.doc._.get(getattr(KNP_USER_KEYS, type_).spans):
+        if token.i < tag_or_bunsetsu.end:
+            return tag_or_bunsetsu
+    raise ValueError("internal error")
+
+
+@curry
 def get_knp_span(type_: str, span: Span) -> List[Span]:
     """Get knp tag or bunsetsu list"""
     assert type_ != MORPH
@@ -193,6 +203,8 @@ def _create_ents(doc: Doc, ents: Iterable[Tuple[str, int, int]]) -> List[Span]:
 def _install_extensions():
     K = KNP_USER_KEYS
     Token.set_extension(K.morph.element, default=None, force=True)
+    for k in ["bunsetsu", "tag"]:
+        Token.set_extension(getattr(K.morph, k), getter=token_to_knp_span(k))
     for k in ["bunsetsu", "morph", "tag"]:
         for feature in ["element", "list_"]:
             key = getattr(getattr(K, k), feature)

--- a/camphr/pipelines/knp/consts.py
+++ b/camphr/pipelines/knp/consts.py
@@ -7,6 +7,8 @@ class KnpUserKeyType(NamedTuple):
     list_: str  # list containing knp elements
     parent: str
     children: str
+    tag: str
+    bunsetsu: str
 
 
 class KnpUserKeys(NamedTuple):

--- a/tests/pipelines/knp/test_knp.py
+++ b/tests/pipelines/knp/test_knp.py
@@ -111,3 +111,18 @@ def test_knp_doc_getter(nlp: Language):
             assert list(doc._.get(key)) == list(
                 itertools.chain.from_iterable(sent._.get(key) for sent in doc.sents)
             )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "偽造パスポートでパラグアイに入国したとして逮捕された、サッカー元ブラジル代表ＦＷロナウジーニョ氏（４０）の保釈が７日に認められた。",
+        "約３８ヘクタールに大型遊具や動物とのふれあい広場などがあり、首都圏でも人気の千葉県船橋市の「ふなばしアンデルセン公園」は８日から全面休園した。",
+    ],
+)
+def test_tag_or_bunsetsu_from_token(nlp: Language, text: str):
+    doc = nlp(text)
+    for k in ["tag", "bunsetsu"]:
+        for span in doc._.get(getattr(KNP_USER_KEYS, k).spans):
+            for token in span:
+                assert token._.get(getattr(KNP_USER_KEYS.morph, k)) == span


### PR DESCRIPTION
Add new extensions: `token._.knp_morph_tag` and `token._.knp_morph_bunsetsu`.
You can directly get the span corresponding pyknp.Tag and pyknp.Bunsetsu from a token, containing it.