### PR TITLE
Improvement for サ変 of KNP

### DIFF
--- a/camphr/pipelines/knp/dependency_parser.py
+++ b/camphr/pipelines/knp/dependency_parser.py
@@ -26,6 +26,9 @@ def knp_dependency_parser(doc: Doc) -> Doc:
     tag_spans: Iterable[Span] = doc._.get(KNP_USER_KEYS.tag.spans)
     s = []
     for tag in tag_spans:
+        for c in tag[1:]:
+            c.head = tag[0]
+            c.dep_ = _get_child_dep(c)
         parent: Optional[Span] = tag._.get(KNP_USER_KEYS.tag.parent)
         if parent is not None:
             tag[0].head = parent[0]
@@ -33,9 +36,6 @@ def knp_dependency_parser(doc: Doc) -> Doc:
         else:
             tag[0].head = tag[0]
             tag[0].dep_ = "ROOT"
-        for c in tag[1:]:
-            c.head = tag[0]
-            c.dep_ = _get_child_dep(c)
         s.append(tag[0])
     s = _modify_head_punct(s)
     s = _modify_head_flat(s)

--- a/tests/pipelines/knp/test_dependency_parser.py
+++ b/tests/pipelines/knp/test_dependency_parser.py
@@ -35,7 +35,8 @@ def test_dependency_deps(nlp, text, deps):
     ("リンゴとバナナとミカン", [0, 0, 0, 2, 0], ["ROOT", "case", "conj", "case", "conj"]),
     ("三匹の豚", [3, 0, 0, 3], ["nummod", "clf", "case", "ROOT"]),
     ("御盃を相交わす", [1, 4, 1, 4, 4], ["compound", "obj", "case", "advmod", "ROOT"]),
-    ("子供を「僕」と呼ぶ", [6, 0, 3, 6, 3, 3, 6], ["obj", "case", "punct", "obl", "punct", "case", "ROOT"])
+    ("子供を「僕」と呼ぶ", [6, 0, 3, 6, 3, 3, 6], ["obj", "case", "punct", "obl", "punct", "case", "ROOT"]),
+    ("地震で半壊した家屋", [2, 0, 4, 2, 4], ["obl", "case", "acl", "aux", "ROOT"])
 ])
 def test_dependency_parse_deps(nlp, text, heads, deps):
     doc = nlp(text)


### PR DESCRIPTION
Inside _get_child_dep(c), `pos` for 名詞,サ変名詞 is changed into `VERB` when it is followed by `AUX`. So now I think that _get_dep(tag[0]) should be done after _get_child_dep(c).