### PR TITLE
improve beamsearch performance for k ==1

### DIFF
--- a/camphr/pipelines/transformers/ner.py
+++ b/camphr/pipelines/transformers/ner.py
@@ -204,7 +204,9 @@ def _create_target(
 
 def get_best_tags(logit: torch.Tensor, id2label: List[str], k_beam: int) -> List[str]:
     """Select best tags from logit based on beamsearch."""
-    candidates = beamsearch(logit.softmax(-1), k_beam)
+    if k_beam > 1:
+        logit = logit.softmax(-1)
+    candidates = beamsearch(logit, k_beam)
     assert len(cast(Sized, candidates))
     best_tags: List[str] = []
     for cand in candidates:

--- a/camphr/pipelines/utils.py
+++ b/camphr/pipelines/utils.py
@@ -194,6 +194,8 @@ def beamsearch(probs: torch.Tensor, k: int) -> torch.Tensor:
     assert len(probs.shape) == 2
     if len(probs) == 0:
         return torch.zeros(k, 0)
+    if k == 1:
+        return probs.argmax(-1)[None, :]
 
     # We calculate top k-th argmax of E = p0p1p2..pn-1.
     # To avoid over(under)flow, evaluete log(E) instead of E.

--- a/tests/pipelines/transformers/test_model.py
+++ b/tests/pipelines/transformers/test_model.py
@@ -33,7 +33,7 @@ def test_forward(nlp, text):
 
 
 def test_pipe(nlp):
-    docs = list(nlp.pipe(TESTCASES))
+    list(nlp.pipe(TESTCASES))
 
 
 @pytest.mark.skip(

--- a/tests/pipelines/transformers/test_model.py
+++ b/tests/pipelines/transformers/test_model.py
@@ -32,6 +32,10 @@ def test_forward(nlp, text):
     assert doc._.transformers_last_hidden_state is not None
 
 
+def test_pipe(nlp):
+    docs = list(nlp.pipe(TESTCASES))
+
+
 @pytest.mark.skip(
     reason="This test fails due to spacy's bug, and will success after the PR is merged: https://github.com/explosion/spaCy/pull/4925"
 )


### PR DESCRIPTION
We shouldn't use the beamsearch algorithm if the width == 1 - simply argmax the logit is sufficient.